### PR TITLE
Reverting out the changes replacing WebRtcMediaSource and

### DIFF
--- a/org/webrtc/wrapper/Media.h
+++ b/org/webrtc/wrapper/Media.h
@@ -19,7 +19,7 @@
 #include "WinUWPDeviceManager.h"
 #include "webrtc/modules/audio_device/include/audio_device.h"
 #include "Delegates.h"
-#include "RTMediaStreamSource.h"
+#include "WebRtcMediaSource.h"
 
 using Platform::String;
 using Windows::Foundation::IAsyncOperation;
@@ -496,7 +496,7 @@ namespace Org {
 				Internal::VideoFrameType _frameType;
 				MediaElement^ _mediaElement;
 				String^ _id;
-				Internal::RTMediaStreamSource^ _mediaSource;
+				ComPtr<Internal::WebRtcMediaSource> _mediaSource;
 			};
 
 			struct VideoTrackMediaElementPair {
@@ -530,15 +530,18 @@ namespace Org {
 				RTCMediaStreamConstraints^ mediaStreamConstraints);
 
 			/// <summary>
-			/// Creates an <see cref="IMediaSource"/>  for H264 frames with a given
+			/// Creates an <see cref="IMediaSource"/> for a video track, with a given
 			/// identifier to be used for notifications on media changes.
 			/// </summary>
+			/// <param name="track">Video track to create a <see cref="IMediaSource"/>
+			/// from</param>
 			/// <param name="id">Identifier that can be used by applications for
 			/// distinguishing between <see cref="MediaStream"/>s
 			/// when receiving media change event notifications.
 			/// </param>
 			/// <returns>A media source.</returns>
-			IMediaSource^ CreateMediaStreamSource(String^ id);
+			//IMediaSource^ CreateMediaStreamSource(
+			//	MediaVideoTrack^ track, uint32 framerate, String^ id);
 
 			/// <summary>
 			/// Adds Video Track and Media Element piar structure to keep a reference
@@ -558,6 +561,22 @@ namespace Org {
 			/// <param name="track">Video track used as a frame source which ientifies
 			/// the pair to be removed</param>
 			void RemoveVideoTrackMediaElementPair(MediaVideoTrack^ track);
+
+			/// <summary>
+			/// Creates an <see cref="IMediaSource"/> for a video track, with a given
+			/// frame rate and identifier to be used for notifications on media
+			/// changes.
+			/// </summary>
+			/// <param name="track">Video track to create a <see cref="IMediaSource"/>
+			/// from</param>
+			/// <param name="framerate">Target frame rate</param>
+			/// <param name="id">Identifier that can be used by applications for
+			/// distinguishing between <see cref="MediaStream"/>s
+			/// when receiving media change event notifications.
+			/// </param>
+			/// <returns>A media source.</returns>
+			//IMediaSource^ CreateMediaSource(
+			//	MediaVideoTrack^ track, String^ id);
 
 			/// <summary>
 			/// Creates an <see cref="RawVideoSource"/> for a video track.

--- a/org/webrtc/wrapper/MediaSourceHelper.cc
+++ b/org/webrtc/wrapper/MediaSourceHelper.cc
@@ -111,30 +111,28 @@ namespace Org {
 					data = DequeueI420Frame();
 				}
 
-				if (_frameType == FrameTypeI420) {
-					// Set the timestamp property
-					if (_isFirstFrame) {
-						_isFirstFrame = false;
-						Org::WebRtc::FirstFrameRenderHelper::FireEvent(
-							rtc::TimeMillis() * rtc::kNumMillisecsPerSec);
-						LONGLONG frameTime = GetNextSampleTimeHns(data->renderTime, _frameType == FrameTypeH264);
-						data->sample->SetSampleTime(frameTime);
+				// Set the timestamp property
+				if (_isFirstFrame) {
+					_isFirstFrame = false;
+					Org::WebRtc::FirstFrameRenderHelper::FireEvent(
+						rtc::TimeMillis() * rtc::kNumMillisecsPerSec);
+					LONGLONG frameTime = GetNextSampleTimeHns(data->renderTime, _frameType == FrameTypeH264);
+					data->sample->SetSampleTime(frameTime);
+				}
+				else {
+					LONGLONG frameTime = GetNextSampleTimeHns(data->renderTime, _frameType == FrameTypeH264);
+
+					data->sample->SetSampleTime(frameTime);
+
+					// Set the duration property
+					if (_frameType == FrameTypeH264) {
+						data->sample->SetSampleDuration(frameTime - _lastSampleTime);
 					}
 					else {
-						LONGLONG frameTime = GetNextSampleTimeHns(data->renderTime, _frameType == FrameTypeH264);
-
-						data->sample->SetSampleTime(frameTime);
-
-						// Set the duration property
-						if (_frameType == FrameTypeH264) {
-							data->sample->SetSampleDuration(frameTime - _lastSampleTime);
-						}
-						else {
-							LONGLONG duration = (LONGLONG)((1.0 / 30) * 1000 * 1000 * 10);
-							data->sample->SetSampleDuration(duration);
-						}
-						_lastSampleTime = frameTime;
+						LONGLONG duration = (LONGLONG)((1.0 / 30) * 1000 * 1000 * 10);
+						data->sample->SetSampleDuration(duration);
 					}
+					_lastSampleTime = frameTime;
 				}
 
 				UpdateFrameRate();

--- a/projects/msvc/Org.WebRtc.Universal/Org.WebRtc.vcxproj
+++ b/projects/msvc/Org.WebRtc.Universal/Org.WebRtc.vcxproj
@@ -33,7 +33,8 @@
     <ClCompile Include="..\..\..\org\webrtc\wrapper\Media.cc" />
     <ClCompile Include="..\..\..\org\webrtc\wrapper\MediaSourceHelper.cc" />
     <ClCompile Include="..\..\..\org\webrtc\wrapper\PeerConnectionInterface.cc" />
-    <ClCompile Include="..\..\..\org\webrtc\wrapper\RTMediaStreamSource.cc" />
+    <ClCompile Include="..\..\..\org\webrtc\wrapper\WebRtcMediaSource.cc" />
+    <ClCompile Include="..\..\..\org\webrtc\wrapper\WebRtcMediaStream.cc" />
     <ClCompile Include="..\..\..\org\webrtc\wrapper\WinUWPDeviceManager.cc" />
   </ItemGroup>
   <ItemGroup>
@@ -45,7 +46,8 @@
     <ClInclude Include="..\..\..\org\webrtc\wrapper\MediaSourceHelper.h" />
     <ClInclude Include="..\..\..\org\webrtc\wrapper\PeerConnectionInterface.h" />
     <ClInclude Include="..\..\..\org\webrtc\wrapper\RTCStatsReport.h" />
-    <ClInclude Include="..\..\..\org\webrtc\wrapper\RTMediaStreamSource.h" />
+    <ClInclude Include="..\..\..\org\webrtc\wrapper\WebRtcMediaSource.h" />
+    <ClInclude Include="..\..\..\org\webrtc\wrapper\WebRtcMediaStream.h" />
     <ClInclude Include="..\..\..\org\webrtc\wrapper\WinUWPDeviceManager.h" />
   </ItemGroup>
   <ItemGroup>

--- a/projects/msvc/Org.WebRtc.Universal/Org.WebRtc.vcxproj.filters
+++ b/projects/msvc/Org.WebRtc.Universal/Org.WebRtc.vcxproj.filters
@@ -13,8 +13,9 @@
     <ClCompile Include="..\..\..\org\webrtc\wrapper\Media.cc" />
     <ClCompile Include="..\..\..\org\webrtc\wrapper\MediaSourceHelper.cc" />
     <ClCompile Include="..\..\..\org\webrtc\wrapper\PeerConnectionInterface.cc" />
-    <ClCompile Include="..\..\..\org\webrtc\wrapper\RTMediaStreamSource.cc" />
     <ClCompile Include="..\..\..\org\webrtc\wrapper\WinUWPDeviceManager.cc" />
+    <ClCompile Include="..\..\..\org\webrtc\wrapper\WebRtcMediaStream.cc" />
+    <ClCompile Include="..\..\..\org\webrtc\wrapper\WebRtcMediaSource.cc" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\..\org\webrtc\wrapper\DataChannel.h" />
@@ -25,7 +26,8 @@
     <ClInclude Include="..\..\..\org\webrtc\wrapper\MediaSourceHelper.h" />
     <ClInclude Include="..\..\..\org\webrtc\wrapper\PeerConnectionInterface.h" />
     <ClInclude Include="..\..\..\org\webrtc\wrapper\RTCStatsReport.h" />
-    <ClInclude Include="..\..\..\org\webrtc\wrapper\RTMediaStreamSource.h" />
     <ClInclude Include="..\..\..\org\webrtc\wrapper\WinUWPDeviceManager.h" />
+    <ClInclude Include="..\..\..\org\webrtc\wrapper\WebRtcMediaStream.h" />
+    <ClInclude Include="..\..\..\org\webrtc\wrapper\WebRtcMediaSource.h" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
WebRtcMediaStream with RTMediaStreamSource. This rewrite
results in broken video playback for the recorder webrtc,
so removing it for now.