### PR TITLE
Fixed issue where DataChannelObserver was being double deleted,

### DIFF
--- a/org/webrtc/wrapper/GlobalObserver.cc
+++ b/org/webrtc/wrapper/GlobalObserver.cc
@@ -321,12 +321,10 @@ namespace Org {
 							Windows::UI::Core::CoreDispatcherPriority::Normal,
 							ref new Windows::UI::Core::DispatchedHandler([this] {
 							_channel->OnClose();
-							delete this;
 						}));
 					}
 					else {
 						_channel->OnClose();
-						delete this;
 					}
 					break;
 				}


### PR DESCRIPTION
which was causing an access violation crash.